### PR TITLE
Composer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Include init.php which sets up the autoloader
 
     require_once YOUR_FBMOCKS_DIR.'/init.php'
 
+### Install using Composer (optional)
+
+To install this package via composer, just add the package to `require` and start using it.
+    
+    {
+        "require": {
+            "facebook/fbmock": "*@dev"
+        }
+    }
+
 ### Creating a mock
 
     mock('Foo')

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "files": ["init.php"]
-    }
+        "classmap": ["."],
+        "files": ["Mock.php"]
+    },
+    "require": {
+        "php": ">=5.4.0"
+    }    
 }


### PR DESCRIPTION
Adjusted the autoloading to use your autoloader.
Added more info on the package.
Added README instructions
Added php 5.4 constraint

**Steps needed from Facebook**
This package still needs to be added to Packagist, for this please visit: https://packagist.org/packages/submit
Create an account and add this repo's address, the rest is all good. I do recommend that you tag a stable release once its ready, right now the package is flagged as `dev`
