### PR TITLE
Disallow mocking internal classes in Zend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Include init.php which sets up the autoloader
 ### Install using Composer (optional)
 
 To install this package via composer, just add the package to `require` and start using it.
-    
+
     {
         "require": {
             "facebook/fbmock": "*@dev"
@@ -97,6 +97,10 @@ If any unmocked method is called, the mock will throw.
 ### Customizing
 
 See CustomConfig-sample.php for instructions on customizing FBMock for your needs.
+
+### Limitations
+
+- Doesn't support mocking of internal PHP classes in Zend PHP
 
 ### Community
 

--- a/TestDoubleCreator.php
+++ b/TestDoubleCreator.php
@@ -28,8 +28,17 @@ class FBMock_TestDoubleCreator {
 
     $class_generator_class = FBMock_Config::get()->getClassGenerator();
     $class_generator = new $class_generator_class();
+    $ref_class = new ReflectionClass($class_name);
+
+    if ($ref_class->isInternal() && !FBMock_Utils::isHPHP()) {
+      throw new FBMock_TestDoubleException(
+        "Trying to mock PHP internal class $class_name. Mocking of internal ".
+        "classes is not supported in Zend."
+      );
+    }
+
     $code = $class_generator->generateCode(
-      new ReflectionClass($class_name),
+      $ref_class,
       $mock_class_name,
       $interfaces,
       $traits,
@@ -37,25 +46,8 @@ class FBMock_TestDoubleCreator {
     );
     eval($code);
 
-    $use_serialize = false;
-    $hierarchy = class_parents($class_name);
-    $hierarchy[$class_name] = $class_name;
-
-    foreach ($hierarchy as $class) {
-      if ((new ReflectionClass($class))->isInternal()) {
-        $use_serialize = true;
-        break;
-      }
-    }
-
-    if ($use_serialize) {
-      $mock_object = unserialize(
-        sprintf('O:%d:"%s":0:{}', strlen($mock_class_name), $mock_class_name)
-      );
-    } else {
-      $mock_object = (new ReflectionClass($mock_class_name))
-        ->newInstanceWithoutConstructor();
-    }
+    $mock_object = (new ReflectionClass($mock_class_name))
+      ->newInstanceWithoutConstructor();
 
     $mock_object->__mockImplementation =
       new FBMock_MockImplementation($class_name);

--- a/TestDoubleMethodGenerator.php
+++ b/TestDoubleMethodGenerator.php
@@ -78,7 +78,7 @@ class FBMock_TestDoubleMethodGenerator {
       "throw new FBMock_TestDoubleException('Call to static method %s on ".
       "%s. Mocks and fakes don\'t support static methods');",
       $method->getName(),
-      $method->getDeclaringClass()
+      $method->getDeclaringClass()->getName()
     );
   }
 

--- a/__tests__/MockObjectTestCase.php
+++ b/__tests__/MockObjectTestCase.php
@@ -169,8 +169,18 @@ class MockObjectTestCase extends FBMock_BaseTestCase {
     $this->assertTrue(mock('ObjectWithWakeup') instanceof ObjectWithWakeup);
   }
 
-  public function testMockInternalClass() {
-    mock('FBMock_TestReflectionMethod');
+  /**
+   * @expectedException FBMock_TestDoubleException
+   * @expectedExceptionMessage Trying to mock PHP internal class DateTime. Mocking of internal classes is not supported in Zend.
+   */
+  public function testMockInternalClassZend() {
+    self::skipInHPHP();
+    mock('DateTime');
+  }
+
+  public function testMockInternalClassHPHP() {
+    self::skipInZend();
+    mock('DateTime');
   }
 }
 
@@ -194,10 +204,4 @@ class TestImplementClass implements TestMockObjectInterface {
 
 interface TestMockObjectInterface {
   public function testMethodSignature();
-}
-
-class FBMock_TestReflectionMethod extends ReflectionMethod {
-  // Default values not available for internal methods. See notes on
-  // http://www.php.net/manual/en/reflectionparameter.getdefaultvalue.php
-  public static function export($class, $name, $return = false) {}
 }

--- a/__tests__/TestDoubleMethodGeneratorTestCase.php
+++ b/__tests__/TestDoubleMethodGeneratorTestCase.php
@@ -5,46 +5,61 @@
  */
 class FBMock_TestDoubleMethodGeneratorTestCase extends FBMock_BaseTestCase {
   private
-    $mockMethod;
+    $refMethod;
 
-  public function setUp() {
-    FBMock_Config::setConfig(new FBMock_MethodGeneratorTestConfig());
-    $this->mockMethod = mock('ReflectionMethod')->mockReturn(array(
-      'getName' => 'test',
-      'isPublic' => true,
-      'getParameters' => array(),
-    ));
+  public static function setUpBeforeClass() {
+    if (FBMock_Utils::isHPHP()) {
+      // Float typehints cause fatal in zend so just eval class
+      eval(<<<'EOD'
+class FBMock_MethodGeneratorTestObjHPHP {
+  public function typehintedPrimitives(int $uid, bool $is_test_user) {}
+
+  public function typehintedAndDefaultedPrimitives(
+    int $uid=0,
+    bool $is_test_user=true,
+    string $nickname="something_cool",
+    Object $o=null) {}
+
+  public function methodWithDecimalDefaults(
+    float $f = 1.0,
+    double $d = 2.0,
+    float $f2 = 1.11,
+    double $d2 = 2.22
+  ) {}
+}
+EOD
+      );
+    }
   }
 
   public function testBasicMethodNoArguments() {
-    $this->mockMethod->mockReturn('getParameters', array());
-    $this->assertCorrectHeader('public function test()');
+    $this->refMethod =
+      new ReflectionMethod('FBMock_MethodGeneratorTestObj::testPublic');
+    $this->assertCorrectHeader('public function testPublic()');
   }
 
   public function testProtectedMethod() {
-    $this->mockMethod->mockReturn('isProtected', true);
-    $this->assertCorrectHeader('protected function test()');
+    $this->refMethod =
+      new ReflectionMethod('FBMock_MethodGeneratorTestObj::testProtected');
+    $this->assertCorrectHeader('protected function testProtected()');
   }
 
   public function testPrivateMethod() {
-    $this->mockMethod->mockReturn('isPrivate', true);
-    $this->assertCorrectHeader('private function test()');
+    $this->refMethod =
+      new ReflectionMethod('FBMock_MethodGeneratorTestObj::testPrivate');
+    $this->assertCorrectHeader('private function testPrivate()');
   }
 
   public function testMethodWithArgumentsNoTypehints() {
-    $this->mockMethod->mockReturn(
-      'getParameters',
-      array(
-        $this->createParam('uid'),
-        $this->createParam('is_test_user'),
-      )
+    $this->refMethod =
+      new ReflectionMethod('FBMock_MethodGeneratorTestObj::typehints1');
+    $this->assertCorrectHeader(
+      'public function typehints1($uid, $is_test_user)'
     );
-
-    $this->assertCorrectHeader('public function test($uid, $is_test_user)');
   }
 
   public function testMethodWithTypehintedArguments() {
-    $this->mockMethod = new ReflectionMethod(
+    $this->refMethod = new ReflectionMethod(
       'FBMock_MethodGeneratorTestObj::methodWithHintsAndDefaults'
     );
 
@@ -68,36 +83,24 @@ EOD;
   public function testMethodWithTypehintedPrimitives() {
     self::skipInZend();
 
-    $this->mockMethod->mockReturn(
-      'getParameters',
-      array(
-        $this->createParam('uid', 'int'),
-        $this->createParam('is_test_user', 'bool'),
-      )
+    $this->refMethod = new ReflectionMethod(
+      'FBMock_MethodGeneratorTestObjHPHP::typehintedPrimitives'
     );
-
     $this->assertCorrectHeader(
-      'public function test(int $uid, bool $is_test_user)'
+      'public function typehintedPrimitives(int $uid, bool $is_test_user)'
     );
   }
 
   public function testMethodWithTypehintedAndDefaultedPrimitives() {
     self::skipInZend();
 
-    $this->mockMethod->mockReturn(
-      'getParameters',
-      array(
-        $this->createParam('uid', 'int', '0'),
-        $this->createParam('is_test_user', 'bool', 'true'),
-        $this->createParam('nickname', 'string', '"something_cool"'),
-        $this->createParam('o', 'Object', 'null'),
-      )
+    $this->refMethod = new ReflectionMethod(
+      'FBMock_MethodGeneratorTestObjHPHP::typehintedAndDefaultedPrimitives'
     );
-
     $this->assertCorrectHeader(
-      'public function test('.
+      'public function typehintedAndDefaultedPrimitives('.
       'int $uid=0, bool $is_test_user=true, '.
-      'string $nickname="something_cool", Object $o=null)'
+      'string $nickname="something_cool", Object $o=NULL)'
     );
   }
 
@@ -117,7 +120,7 @@ class FBMock_MethodGeneratorTestObj2 {
 EOD;
 
     eval($class);
-    $this->mockMethod = new ReflectionMethod(
+    $this->refMethod = new ReflectionMethod(
       'FBMock_MethodGeneratorTestObj2::methodWithDecimalDefaults'
     );
 
@@ -131,39 +134,40 @@ EOD;
    * Make sure body is also correct
    */
   public function testMethodWithBody() {
-    $this->mockMethod->mockReturn(
-      'getParameters',
-      array($this->createParam('uid'))
-    )->mockReturn('getDeclaringClass', 'TestClass');
-
+    $this->refMethod = new ReflectionMethod(
+      'FBMock_MethodGeneratorTestObj::testPublic'
+    );
     $test_double_method_generator = new FBMock_TestDoubleMethodGenerator();
     $this->assertEquals(
-      'public function test($uid) {'."\n".
+      'public function testPublic() {'."\n".
         '  return $this->__mockImplementation'.
         "->processMethodCall(__FUNCTION__, func_get_args());\n}",
-      $test_double_method_generator->generateCode($this->mockMethod)
+      $test_double_method_generator->generateCode($this->refMethod)
     );
 
-    $this->assertEquals(
-      'public static function test($uid) {'."\n".
-      "  throw new FBMock_TestDoubleException('Call to static method test ".
-      "on TestClass. Mocks and fakes don\'t support static methods');\n}",
-      $test_double_method_generator->generateCode(
-        $this->mockMethod->mockReturn('isStatic', true)
-      )
+    $this->refMethod = new ReflectionMethod(
+      'FBMock_MethodGeneratorTestObj::testStatic'
+    );
+    $this->assertEquals(<<<'EOD'
+public static function testStatic() {
+  throw new FBMock_TestDoubleException('Call to static method testStatic on FBMock_MethodGeneratorTestObj. Mocks and fakes don\'t support static methods');
+}
+EOD
+      ,
+      $test_double_method_generator->generateCode($this->refMethod)
     );
   }
 
   public function testMockMagicCall() {
-    $this->mockMethod->mockReturn('getName', '__call');
-
+    $this->refMethod =
+      new ReflectionMethod('FBMock_MethodGeneratorTestObj::__call');
     $test_double_method_generator = new FBMock_TestDoubleMethodGenerator();
     $this->assertEquals(
-      'public function __call() {'."\n".
+      'public function __call($method_name, $args) {'."\n".
       '  return $this->__mockImplementation'.
       '->processMethodCall('.
       "func_get_args()[0], func_get_args()[1]);\n}",
-      $test_double_method_generator->generateCode($this->mockMethod)
+      $test_double_method_generator->generateCode($this->refMethod)
     );
   }
 
@@ -172,54 +176,22 @@ EOD;
     $test_double_method_generator = new FBMock_TestDoubleMethodGenerator();
     $this->assertEquals(
       $expected,
-      $test_double_method_generator->getMethodHeader($this->mockMethod)
+      $test_double_method_generator->getMethodHeader($this->refMethod)
     );
-  }
-
-  private function createParam(
-      $name,
-      $type = '',
-      $default = '') {
-    $mock = mock('ReflectionParameter')
-      ->mockReturn('getName', $name)
-      ->mockReturn('isDefaultValueAvailable', $default !== '');
-
-    if (method_exists($mock, 'getTypehintText')) {
-      $mock->mockReturn('getTypehintText', $type);
-    }
-
-    if (method_exists($mock, 'getDefaultValueText')) {
-      $mock->mockReturn('getDefaultValueText', $default);
-    }
-
-    return $mock;
   }
 }
 
 class FBMock_MethodGeneratorTestObj {
+  public function testPublic() {}
+  protected function testProtected() {}
+  private function testPrivate() {}
+  public static function testStatic() {}
+
+  public function typehints1($uid, $is_test_user) {}
+  public function __call($method_name, $args) {}
   public function methodWithHintsAndDefaults(
     stdClass $o,
     array $a = array('asdf'),
     $n = NULL) { }
   public function methodWithBadTypehint(ClassThatDoesNotExist $a) {}
-}
-
-class FBMock_MethodGeneratorTestConfig extends FBMock_Config {
-  public function getMethodGenerator() {
-    return new FBMock_MethodGeneratorForTest();
-  }
-}
-
-class FBMock_MethodGeneratorForTest extends FBMock_TestDoubleMethodGenerator {
-  public function generateCode(ReflectionMethod $method) {
-    // Can't get default value for last parameter to export because zend doesn't
-    // allow you to get default values for built-ins and having a different
-    // method signature than the method you are overriding causes an error in
-    // strict standards mode. See note at bottom of
-    // http://php.net/manual/en/reflectionparameter.getdefaultvalue.php
-    if ($method->getName() == 'export' || $method->isFinal()) {
-      return null;
-    }
-    return parent::generateCode($method);
-  }
 }


### PR DESCRIPTION
Disallow mocking internal classes in Zend due to issues constructing the class and inability to get correct default values for params on interal class methods.
