### PR TITLE
Some small fixes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ To install this package via composer, just add the package to `require` and star
             "facebook/fbmock": "*@dev"
         }
     }
+    
+When using composer, the require of `init.php` is no longer necessary.
 
 ### Creating a mock
 


### PR DESCRIPTION
I've made two small changes to improve the README file:
- Fixed a code snippet markdown error
- Noted that requiring `init.php` is not necessary when installing FBMock via composer
