### PR TITLE
Support method parameter passed by reference

### DIFF
--- a/TestDoubleMethodGenerator.php
+++ b/TestDoubleMethodGenerator.php
@@ -68,8 +68,12 @@ class FBMock_TestDoubleMethodGenerator {
     if ($typehint_type) {
       $code .= $typehint_type.' ';
     }
-
-    $code .= '$'.$param->getName();
+    if($param->isPassedByReference()) {
+      $code .= '&$'.$param->getName();  
+    } else {
+      $code .= '$'.$param->getName();  
+    }
+    
 
     if ($param->isDefaultValueAvailable()) {
       $code .= '='.$this->getDefaultParameterValue($param);


### PR DESCRIPTION
It's not possible to mock a class with an interface that has a method with a parameter passed by reference.  This fixes it.
