### PR TITLE
Refactoring tests

### DIFF
--- a/__tests__/MockObjectTestCase.php
+++ b/__tests__/MockObjectTestCase.php
@@ -73,22 +73,22 @@ class MockObjectTestCase extends FBMock_BaseTestCase {
 
   public function testMockImplementsInterface() {
     $mock = mock('TestObject');
-    $this->assertTrue($mock instanceof TestObject);
-    $this->assertFalse($mock instanceof TestImplementClass);
-    $this->assertFalse($mock instanceof TestMockObjectInterface);
+    $this->assertInstanceOf('TestObject', $mock);
+    $this->assertNotInstanceOf('TestImplementClass', $mock);
+    $this->assertNotInstanceOf('TestMockObjectInterface', $mock);
     $mock = mock('TestImplementClass', 'TestMockObjectInterface');
-    $this->assertFalse($mock instanceof TestObject);
-    $this->assertTrue($mock instanceof TestImplementClass);
-    $this->assertTrue($mock instanceof TestMockObjectInterface);
+    $this->assertNotInstanceOf('TestObject', $mock);
+    $this->assertInstanceOf('TestImplementClass', $mock);
+    $this->assertInstanceOf('TestMockObjectInterface', $mock);
 
     $mock = strict_mock('TestObject');
-    $this->assertTrue($mock instanceof TestObject);
-    $this->assertFalse($mock instanceof TestImplementClass);
-    $this->assertFalse($mock instanceof TestMockObjectInterface);
+    $this->assertInstanceOf('TestObject', $mock);
+    $this->assertNotInstanceOf('TestImplementClass', $mock);
+    $this->assertNotInstanceOf('TestMockObjectInterface', $mock);
     $mock = strict_mock('TestImplementClass', 'TestMockObjectInterface');
-    $this->assertFalse($mock instanceof TestObject);
-    $this->assertTrue($mock instanceof TestImplementClass);
-    $this->assertTrue($mock instanceof TestMockObjectInterface);
+    $this->assertNotInstanceOf('TestObject', $mock);
+    $this->assertInstanceOf('TestImplementClass', $mock);
+    $this->assertInstanceOf('TestMockObjectInterface', $mock);
   }
 
   /**
@@ -166,7 +166,7 @@ class MockObjectTestCase extends FBMock_BaseTestCase {
   }
 
   public function testMockWithWakeup() {
-    $this->assertTrue(mock('ObjectWithWakeup') instanceof ObjectWithWakeup);
+    $this->assertInstanceOf('ObjectWithWakeup', mock('ObjectWithWakeup'));
   }
 
   /**

--- a/__tests__/MockRegressionTests.php
+++ b/__tests__/MockRegressionTests.php
@@ -37,9 +37,9 @@ class MockRegressionTests extends FBMock_BaseTestCase {
     $a = array(mock('TestChild'), mock('TestChild'));
     sort($a);
 
-    $this->assertTrue(mock('TestChild') == mock('TestChild'));
-    $this->assertFalse(
-      mock('TestChild') == mock('TestChild')->mockReturn('testMethod', 1)
+    $this->assertEquals(mock('TestChild'), mock('TestChild'));
+    $this->assertNotEquals(
+      mock('TestChild'), mock('TestChild')->mockReturn('testMethod', 1)
     );
   }
 }


### PR DESCRIPTION
I've refactored some tests using:
- `assertInstanceOf` and `assertNotInstanceOf` instead of `instanceof` operator;
- `assertEquals` and `assertNotEquals` instead of comparisons `==`.